### PR TITLE
Fix autoencoders broken after keras update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Depends:
     R (>= 3.2)
 Imports: 
     graphics (>= 3.2.3),
-    keras (>= 2.1.5),
+    keras (>= 2.2.4),
     purrr (>= 0.2.4),
     stats (>= 3.2.3),
     utils

--- a/R/autoencoder.R
+++ b/R/autoencoder.R
@@ -134,8 +134,8 @@ to_keras.ruta_autoencoder <- function(learner, encoder_end = "encoding", decoder
 
   decoder_stack <- decoder_input
   for (lay_i in start:end) {
-    # zero-based index
-    decoder_stack <- keras::get_layer(model, index = lay_i)(decoder_stack)
+    # one-based index
+    decoder_stack <- keras::get_layer(model, index = lay_i + 1)(decoder_stack)
   }
 
   decoder <- keras::keras_model(decoder_input, decoder_stack)

--- a/R/autoencoder_contractive.R
+++ b/R/autoencoder_contractive.R
@@ -99,7 +99,7 @@ to_keras.ruta_loss_contraction <- function(x, learner, ...) {
       keras::k_square() %>%
       keras::k_sum(axis = 2)
 
-    dh2 <- act_der(encoding_h$input, encoding_h$output) ** 2
+    dh2 <- act_der(encoding_h$input, keras::get_output_at(encoding_h, 1)) ** 2
 
     contractive <- x$weight * keras::k_sum(dh2 * sum_wt2, axis = 2)
 


### PR DESCRIPTION
Contractive and variational autoencoders were broken because all indices are now one-based.